### PR TITLE
Add documentation to functions and in the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc/
 .erlang.mk/
 zipper.d
 .eunit

--- a/src/zipper_default.erl
+++ b/src/zipper_default.erl
@@ -2,6 +2,7 @@
 
 -export([list/1, bin_tree/1, map_tree/2]).
 
+%% @doc Generates a zipper for lists.
 -spec list(list()) -> zipper:zipper(list()).
 list(Root) ->
     IsBranchFun = fun is_list/1,
@@ -9,6 +10,7 @@ list(Root) ->
     MakeNodeFun = fun(_Node, Children) -> Children end,
     zipper:new(IsBranchFun, ChildrenFun, MakeNodeFun, Root).
 
+%% @doc Generates a zipper for binary trees.
 -type bin_tree_node(T) :: nil | {T, bin_tree_node(T), bin_tree_node(T)}.
 -spec bin_tree(bin_tree_node(T)) -> zipper:zipper(bin_tree_node(T)).
 bin_tree(Root) ->
@@ -20,6 +22,7 @@ bin_tree(Root) ->
     MakeNodeFun = fun(Node, [Left, Right]) -> {Node, Left, Right} end,
     zipper:new(IsBranchFun, ChildrenFun, MakeNodeFun, Root).
 
+%% @doc Generates a zipper for maps.
 -spec map_tree(M, CK) -> zipper:zipper(M) when M :: #{K => _}, CK :: K.
 map_tree(Root, ChildrenKey) ->
     IsBranchFun = fun (M) ->


### PR DESCRIPTION
There's a typo in the docs [here](https://github.com/inaka/zipper/blob/master/src/zipper.erl#L269).