### PR TITLE
Mark parent info as modified when moving up in zipper

### DIFF
--- a/src/zipper.erl
+++ b/src/zipper.erl
@@ -90,7 +90,8 @@ up(#{spec := #{make_node := MakeNode},
        Zipper) ->
     Children = lists:reverse(Lefts) ++ [Node | Rights],
     NewParentNode = MakeNode(ParentNode, Children),
-    Zipper#{node => NewParentNode, info => ParentInfo};
+    NewParentInfo = maps:put(is_modified, true, ParentInfo),
+    Zipper#{node => NewParentNode, info => NewParentInfo};
 up(#{info := #{parent_node := Parent, parent_info := ParentInfo}} = Zipper) ->
     Zipper#{node => Parent, info => ParentInfo}.
 

--- a/test/zipper_SUITE.erl
+++ b/test/zipper_SUITE.erl
@@ -136,7 +136,7 @@ zipper_up_modified(_Config) ->
   Zipper3 = zipper:up(Zipper2),
   Zipper4 = zipper:traverse([next, next, next], Zipper3),
   Attrs = maps:get(attrs, zipper:node(Zipper4)),
-  Attrs = #{name => "Peru"},
+  #{name => "Peru"} = Attrs,
   {comment, ""}.
 
 -spec zipper_right(config()) -> {comment, string()}.

--- a/test/zipper_SUITE.erl
+++ b/test/zipper_SUITE.erl
@@ -4,7 +4,7 @@
 %% Info
 -export([zipper_node/1, zipper_children/1]).
 %% Traverse
--export([zipper_root/1, zipper_next/1, zipper_prev/1, zipper_up/1, zipper_down/1,
+-export([zipper_root/1, zipper_next/1, zipper_prev/1, zipper_up/1, zipper_up_modified/1, zipper_down/1,
          zipper_left/1, zipper_right/1, zipper_leftmost/1, zipper_rightmost/1]).
 %% Editing
 -export([zipper_insert_left/1, zipper_insert_right/1, zipper_replace/1, zipper_edit/1,
@@ -123,6 +123,21 @@ zipper_up(_Config) ->
     Earth = zipper:node(Zipper3),
     Earth = root(),
     {comment, ""}.
+
+-spec zipper_up_modified(config()) -> {comment, string()}.
+zipper_up_modified(_Config) ->
+  Zipper = zipper_default:map_tree(root(), children),
+  undefined = zipper:up(Zipper),
+  Zipper1 = zipper:traverse([next, next, next], Zipper),
+  Brasil = zipper:node(Zipper1),
+  Brasil2 = maps:put(attrs, #{name => "Peru"}, Brasil),
+  ModifiedZipper1 = zipper:replace(Brasil2, Zipper1),
+  Zipper2 = zipper:up(ModifiedZipper1),
+  Zipper3 = zipper:up(Zipper2),
+  Zipper4 = zipper:traverse([next, next, next], Zipper3),
+  Attrs = maps:get(attrs, zipper:node(Zipper4)),
+  Attrs = #{name => "Peru"},
+  {comment, ""}.
 
 -spec zipper_right(config()) -> {comment, string()}.
 zipper_right(_Config) ->


### PR DESCRIPTION
- Added `is_modified` flag set to true in parent info during `up/1` operation.
- Added test `zipper_up_modified/1` to verify the modified flag propagation on zipper manipulations.

I have encountered an issue when modifying a node in a tree, and then moving along the tree.
`zipper:up` does not retain the modified status for traversal to parent nodes, and therefore traversing upwards (like done in `zipper:next_recur`) looses the modified node.

The example test case `zipper_up_modified` should demonstrate the issue.
Here is a graphical representation:

```
planet "earth"
\_ continent "America"
  |_ country "Argentina"
  \_ country "Brasil"

Moving the tree to country "Brasil" and changing it to country "Peru" causes the following issue:

1. Replacing the node country "Brasil" with country "Peru" sets is_modified to true
2. Traversing upwards replaces the children of continent "America" correctly. But is_modified is not retained.
3. Traversing upwards again, takes the children of planet "Earth" and therefore looses the updated children of content "America"

With the fix, the behavior is correct:

1. Replacing the node country "Brasil" with country "Peru" sets is_modified to true
2. Traversing upwards replaces the children of continent "America" correctly. Now the node content "America" sets is_modified to true
3. Traversing upwards again, replaces the children of planet "Earth" and therefore retains the updated children of content "America"

=> correct tree state
```

When modifying `country "Brasil"` to, for example, `country "Peru"` the `info => #{ is_modified => true }` is set on the node.
The issue is, that `is_modified` is not propagated when moving upwards with `zipper:up`.
This causes issues with the state of the tree being lost in traversal, due to the children of parents being replaced with their previous versions.

Therefore I changed `zipper:up` to mark the whole lineage with `info => #{ is_modified => true }`.
This makes upwards traversal retain the proper state of the tree, even when traversing further upwards.